### PR TITLE
Clean up logic in SqlInserter

### DIFF
--- a/Model/SqlObject.cs
+++ b/Model/SqlObject.cs
@@ -484,5 +484,10 @@ namespace Truffle.Model
         {
             return columns;
         }
+
+        public List<string> GetColumnNames()
+        {
+            return new List<string>(columns.Keys);
+        }
     }
 }


### PR DESCRIPTION
This pull request simplifies logic in SqlInserter and should slightly improve performance for SqlInserter#InsertWithOutput()

This is achieved by:
- Adding an additional public method in SqlObject for a list of columns
- Referencing this additional method in SqlInserter#BuildOutputCommand()
- Refactoring SqlInserter#BuildCommand() with a StringBuilder for a uniform output
- Providing additional behavior in the case that an SqlObject is not provided